### PR TITLE
Add isKlaviyoEnabled check to product/viewed.phtml

### DIFF
--- a/view/frontend/templates/product/viewed.phtml
+++ b/view/frontend/templates/product/viewed.phtml
@@ -1,5 +1,8 @@
 <?php
 /** @var Klaviyo\Reclaim\Block\Catalog\Product\ViewedProduct $block */
+if (!$block->isKlaviyoEnabled()) {
+    return;
+}
 ?>
 
 <script text="text/javascript">


### PR DESCRIPTION
Logic in product/viewed.phtml is always executed even when you disable the module.

## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->


## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1.

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
